### PR TITLE
build(ci): auto-merge dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,6 @@ updates:
       all:
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "fake"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,0 +1,28 @@
+name: Dependabot auto-merge
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  auto-merge:
+    name: Approve and Auto-Merge
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Approve PR
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: gh pr review --approve "$PR_URL"
+
+      - name: Enable auto-merge
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary
- Add `.github/workflows/dependabot-auto-merge.yaml`: when a Dependabot PR is opened, the workflow approves it as `github-actions[bot]` (satisfies "Require approvals: 1") and runs `gh pr merge --auto --squash`. Auto-merge fires once required CI checks pass.
- Remove the placeholder `ignore: - dependency-name: "fake"` block from `.github/dependabot.yml`.

## Test plan
- [ ] Wait for the next Dependabot PR (or run `@dependabot rebase` on an open one) and verify: workflow runs, approval is recorded, CI passes, PR auto-merges as squash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)