### PR TITLE
chore(build): apply common hseeberger project shape

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{github.workflow}}-${{github.head_ref || github.run_id}}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -18,8 +18,8 @@ jobs:
     name: Setup Rust toolchain
     runs-on: ubuntu-latest
     outputs:
-      stable: ${{steps.set_toolchain.outputs.stable}}
-      nightly: ${{steps.set_toolchain.outputs.nightly}}
+      stable: ${{ steps.set_toolchain.outputs.stable }}
+      nightly: ${{ steps.set_toolchain.outputs.nightly }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -45,7 +45,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
-          toolchain: ${{needs.toolchain.outputs.nightly}}
+          toolchain: ${{ needs.toolchain.outputs.nightly }}
           components: rustfmt
 
       - name: Install just
@@ -71,7 +71,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
-          toolchain: ${{needs.toolchain.outputs.stable}}
+          toolchain: ${{ needs.toolchain.outputs.stable }}
           components: clippy
 
       - name: Install just
@@ -84,7 +84,7 @@ jobs:
 
       - name: just lint
         run: |
-          rustup override set ${{needs.toolchain.outputs.stable}}
+          rustup override set ${{ needs.toolchain.outputs.stable }}
           just lint
 
   test:
@@ -98,7 +98,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
-          toolchain: ${{needs.toolchain.outputs.stable}}
+          toolchain: ${{ needs.toolchain.outputs.stable }}
 
       - name: Install just
         uses: taiki-e/install-action@0c7a94999971db56e9df89df226240aab222e776 # v2.75.14
@@ -110,7 +110,7 @@ jobs:
 
       - name: just test
         run: |
-          rustup override set ${{needs.toolchain.outputs.stable}}
+          rustup override set ${{ needs.toolchain.outputs.stable }}
           just test
 
   doc:
@@ -124,7 +124,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
-          toolchain: ${{needs.toolchain.outputs.nightly}}
+          toolchain: ${{ needs.toolchain.outputs.nightly }}
           components: rust-docs
 
       - name: Install just

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -17,12 +17,12 @@ jobs:
     steps:
       - name: Approve PR
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr review --approve "$PR_URL"
 
       - name: Enable auto-merge
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/release-plz.yaml
+++ b/.github/workflows/release-plz.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Setup Rust toolchain
     runs-on: ubuntu-latest
     outputs:
-      toolchain: ${{steps.set_toolchain.outputs.toolchain}}
+      toolchain: ${{ steps.set_toolchain.outputs.toolchain }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -40,7 +40,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
-          toolchain: ${{needs.toolchain.outputs.toolchain}}
+          toolchain: ${{ needs.toolchain.outputs.toolchain }}
 
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
+.vscode
 .zed
 target

--- a/justfile
+++ b/justfile
@@ -7,14 +7,14 @@ check:
 	cargo check --tests --features axum
 	cargo check --tests --features axum,axum-utoipa
 
+fix:
+	cargo fix --tests --all-features --allow-dirty --allow-staged
+
 fmt:
     cargo +{{nightly}} fmt
 
 fmt-check:
     cargo +{{nightly}} fmt --check
-
-fix:
-	cargo fix --tests --all-features --allow-dirty --allow-staged
 
 lint:
 	cargo clippy --tests --no-deps                             -- -D warnings


### PR DESCRIPTION
## Summary

Align with common hseeberger project shape:

- **`.gitignore`**: canonical entries (`.DS_Store`, `.vscode`, `.zed`, `target`).
- **`justfile`**: reorder recipes to canonical order (`check, fix, fmt, fmt-check, lint, lint-fix, test, doc, all`).
- **Workflows**: idiomatic spacing inside `${{ ... }}` expressions across `ci.yaml`, `dependabot-auto-merge.yaml`, and `release-plz.yaml`.

No behavior change.

## Test plan

- [ ] CI passes (lint, fmt-check, test).