### PR TITLE
chore: release v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4](https://github.com/hseeberger/error-ext/compare/v0.4.3...v0.4.4) - 2026-04-29
+
+### Other
+
+- *(build)* apply common hseeberger project shape ([#206](https://github.com/hseeberger/error-ext/pull/206))
+- *(deps)* bump taiki-e/install-action ([#203](https://github.com/hseeberger/error-ext/pull/203))
+- *(ci)* auto-merge dependabot PRs ([#204](https://github.com/hseeberger/error-ext/pull/204))
+- remove dev container support ([#201](https://github.com/hseeberger/error-ext/pull/201))
+- *(deps)* bump taiki-e/install-action in the all group ([#199](https://github.com/hseeberger/error-ext/pull/199))
+- *(deps)* bump axum from 0.8.8 to 0.8.9 in the all group ([#198](https://github.com/hseeberger/error-ext/pull/198))
+- add dev container support ([#197](https://github.com/hseeberger/error-ext/pull/197))
+- *(deps)* bump taiki-e/install-action in the all group ([#196](https://github.com/hseeberger/error-ext/pull/196))
+- *(deps)* update Rust to 1.94.1 ([#195](https://github.com/hseeberger/error-ext/pull/195))
+- *(deps)* bump Rust to 1.94.0
+- *(deps)* bump dtolnay/rust-toolchain in the all group ([#193](https://github.com/hseeberger/error-ext/pull/193))
+- *(ci)* add cooldown to dependabot
+- *(deps)* bump taiki-e/install-action from 2.69.10 to 2.69.12 ([#191](https://github.com/hseeberger/error-ext/pull/191))
+- *(deps)* bump taiki-e/install-action from 2.69.9 to 2.69.10 ([#190](https://github.com/hseeberger/error-ext/pull/190))
+- add CODEOWNERS ([#189](https://github.com/hseeberger/error-ext/pull/189))
+- *(deps)* bump taiki-e/install-action from 2.69.7 to 2.69.9 ([#188](https://github.com/hseeberger/error-ext/pull/188))
+- *(deps)* bump taiki-e/install-action from 2.69.6 to 2.69.7 ([#187](https://github.com/hseeberger/error-ext/pull/187))
+- *(deps)* bump taiki-e/install-action from 2.69.2 to 2.69.6 ([#186](https://github.com/hseeberger/error-ext/pull/186))
+- *(deps)* bump taiki-e/install-action from 2.68.36 to 2.69.2 ([#185](https://github.com/hseeberger/error-ext/pull/185))
+- *(deps)* bump taiki-e/install-action from 2.68.35 to 2.68.36 ([#184](https://github.com/hseeberger/error-ext/pull/184))
+- *(deps)* bump taiki-e/install-action from 2.68.34 to 2.68.35 ([#183](https://github.com/hseeberger/error-ext/pull/183))
+- *(deps)* bump taiki-e/install-action from 2.68.33 to 2.68.34 ([#182](https://github.com/hseeberger/error-ext/pull/182))
+- *(deps)* bump taiki-e/install-action from 2.68.27 to 2.68.33 ([#181](https://github.com/hseeberger/error-ext/pull/181))
+- *(deps)* bump taiki-e/install-action from 2.68.26 to 2.68.27 ([#179](https://github.com/hseeberger/error-ext/pull/179))
+- *(deps)* bump Swatinem/rust-cache from 2.8.2 to 2.9.1 ([#178](https://github.com/hseeberger/error-ext/pull/178))
+- *(deps)* bump taiki-e/install-action from 2.68.25 to 2.68.26 ([#176](https://github.com/hseeberger/error-ext/pull/176))
+
 ## [0.4.3](https://github.com/hseeberger/error-ext/compare/v0.4.2...v0.4.3) - 2026-03-09
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "error-ext"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "error-ext"
-version       = "0.4.3"
+version       = "0.4.4"
 description   = "Error utilities"
 edition       = "2024"
 authors       = [ "Heiko Seeberger <git@heikoseeberger.de>" ]


### PR DESCRIPTION



## 🤖 New release

* `error-ext`: 0.4.3 -> 0.4.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.4](https://github.com/hseeberger/error-ext/compare/v0.4.3...v0.4.4) - 2026-04-29

### Other

- *(build)* apply common hseeberger project shape ([#206](https://github.com/hseeberger/error-ext/pull/206))
- *(deps)* bump taiki-e/install-action ([#203](https://github.com/hseeberger/error-ext/pull/203))
- *(ci)* auto-merge dependabot PRs ([#204](https://github.com/hseeberger/error-ext/pull/204))
- remove dev container support ([#201](https://github.com/hseeberger/error-ext/pull/201))
- *(deps)* bump taiki-e/install-action in the all group ([#199](https://github.com/hseeberger/error-ext/pull/199))
- *(deps)* bump axum from 0.8.8 to 0.8.9 in the all group ([#198](https://github.com/hseeberger/error-ext/pull/198))
- add dev container support ([#197](https://github.com/hseeberger/error-ext/pull/197))
- *(deps)* bump taiki-e/install-action in the all group ([#196](https://github.com/hseeberger/error-ext/pull/196))
- *(deps)* update Rust to 1.94.1 ([#195](https://github.com/hseeberger/error-ext/pull/195))
- *(deps)* bump Rust to 1.94.0
- *(deps)* bump dtolnay/rust-toolchain in the all group ([#193](https://github.com/hseeberger/error-ext/pull/193))
- *(ci)* add cooldown to dependabot
- *(deps)* bump taiki-e/install-action from 2.69.10 to 2.69.12 ([#191](https://github.com/hseeberger/error-ext/pull/191))
- *(deps)* bump taiki-e/install-action from 2.69.9 to 2.69.10 ([#190](https://github.com/hseeberger/error-ext/pull/190))
- add CODEOWNERS ([#189](https://github.com/hseeberger/error-ext/pull/189))
- *(deps)* bump taiki-e/install-action from 2.69.7 to 2.69.9 ([#188](https://github.com/hseeberger/error-ext/pull/188))
- *(deps)* bump taiki-e/install-action from 2.69.6 to 2.69.7 ([#187](https://github.com/hseeberger/error-ext/pull/187))
- *(deps)* bump taiki-e/install-action from 2.69.2 to 2.69.6 ([#186](https://github.com/hseeberger/error-ext/pull/186))
- *(deps)* bump taiki-e/install-action from 2.68.36 to 2.69.2 ([#185](https://github.com/hseeberger/error-ext/pull/185))
- *(deps)* bump taiki-e/install-action from 2.68.35 to 2.68.36 ([#184](https://github.com/hseeberger/error-ext/pull/184))
- *(deps)* bump taiki-e/install-action from 2.68.34 to 2.68.35 ([#183](https://github.com/hseeberger/error-ext/pull/183))
- *(deps)* bump taiki-e/install-action from 2.68.33 to 2.68.34 ([#182](https://github.com/hseeberger/error-ext/pull/182))
- *(deps)* bump taiki-e/install-action from 2.68.27 to 2.68.33 ([#181](https://github.com/hseeberger/error-ext/pull/181))
- *(deps)* bump taiki-e/install-action from 2.68.26 to 2.68.27 ([#179](https://github.com/hseeberger/error-ext/pull/179))
- *(deps)* bump Swatinem/rust-cache from 2.8.2 to 2.9.1 ([#178](https://github.com/hseeberger/error-ext/pull/178))
- *(deps)* bump taiki-e/install-action from 2.68.25 to 2.68.26 ([#176](https://github.com/hseeberger/error-ext/pull/176))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).