### PR TITLE
chore: standardize project scaffolding and package metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
+.claude
+.envrc.local
 .vscode
 .zed
 target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name          = "error-ext"
-version       = "0.4.5"
 description   = "Error utilities"
+version       = "0.4.5"
 edition       = "2024"
-authors       = [ "Heiko Seeberger <git@heikoseeberger.de>" ]
-license-file  = "LICENSE"
+license       = "Apache-2.0"
 readme        = "README.md"
 homepage      = "https://github.com/hseeberger/error-ext"
 repository    = "https://github.com/hseeberger/error-ext"
 documentation = "https://docs.rs/error-ext/latest/error_ext/"
+publish       = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/justfile
+++ b/justfile
@@ -3,33 +3,34 @@ set shell := ["bash", "-uc"]
 nightly := `rustc --version | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | sed 's/^/nightly-/'`
 
 check:
-	cargo check --tests
-	cargo check --tests --features axum
-	cargo check --tests --features axum,axum-utoipa
+    cargo check --tests
+    cargo check --tests --features axum
+    cargo check --tests --features axum,axum-utoipa
 
 fix:
-	cargo fix --tests --all-features --allow-dirty --allow-staged
+    cargo fix --tests --all-features --allow-dirty --allow-staged
 
 fmt:
-    cargo +{{nightly}} fmt
+    cargo +{{ nightly }} fmt
+    RUST_LOG=error taplo fmt
 
 fmt-check:
-    cargo +{{nightly}} fmt --check
+    cargo +{{ nightly }} fmt --check
 
 lint:
-	cargo clippy --tests --no-deps                             -- -D warnings
-	cargo clippy --tests --no-deps --features axum             -- -D warnings
-	cargo clippy --tests --no-deps --features axum,axum-utoipa -- -D warnings
+    cargo clippy --tests --no-deps                             -- -D warnings
+    cargo clippy --tests --no-deps --features axum             -- -D warnings
+    cargo clippy --tests --no-deps --features axum,axum-utoipa -- -D warnings
 
 lint-fix:
-	cargo clippy --tests --no-deps --all-features --allow-dirty --allow-staged --fix
+    cargo clippy --tests --no-deps --all-features --allow-dirty --allow-staged --fix
 
 test:
-	cargo test --tests
-	cargo test --tests --features axum
-	cargo test --tests --features axum,axum-utoipa
+    cargo test --tests
+    cargo test --tests --features axum
+    cargo test --tests --features axum,axum-utoipa
 
 doc:
-	RUSTDOCFLAGS="-D warnings --cfg docsrs" cargo +{{nightly}} doc --no-deps --all-features
+    RUSTDOCFLAGS="-D warnings --cfg docsrs" cargo +{{ nightly }} doc --no-deps --all-features
 
 all: check fmt lint test doc


### PR DESCRIPTION
Standardize scaffolding, CI config, and package metadata to the shared template.

- `justfile`: 4-space indentation, `taplo fmt` in the `fmt` recipe
- `.gitignore`: canonical entries, sorted
- `Cargo.toml`: SPDX license, no `authors`, docs.rs `documentation`, consistent field order, explicit `publish`
- workflows / rustfmt edition aligned where applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)