### PR TITLE
docs: turn on warnings for missing docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 
 //! Error utilities.
 
+#![warn(missing_docs)]
+
 #[cfg(feature = "axum")]
 #[cfg_attr(docsrs, doc(cfg(feature = "axum")))]
 pub mod axum;


### PR DESCRIPTION
Enables `#![warn(missing_docs)]` on the crate. All public items were already documented.